### PR TITLE
Adding dockerfile and basic client for CI version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,6 @@ workflows:
       - docker-publish/publish:
           image: singularityhub/sif
           deploy: false
-          filters:
-            branches:
-              ignore: master
-
-  docker_with_lifecycle:
-    jobs:
-      - docker-publish/publish:
-          image: singularityhub/sif
-          deploy: false
           tag: latest
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ workflows:
           tag: latest
           filters:
             branches:
-              ignore: master
+             only: master
           after_build:
             - run:
                 name: Publish Docker Tag with SIF Python Version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
   build_without_publishing_job:
     jobs:
       - docker-publish/publish:
-          image: singularityhub/sif:latest
+          image: singularityhub/sif
           deploy: false
           filters:
             branches:
@@ -18,6 +18,7 @@ workflows:
   docker_with_lifecycle:
     jobs:
       - docker-publish/publish:
+          image: singularityhub/sif
           deploy: false
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
       - docker-publish/publish:
           image: singularityhub/sif
           deploy: false
+          tag: latest
           filters:
             branches:
               ignore: master
@@ -27,24 +28,23 @@ workflows:
             - run:
                 name: Preview Docker Tag for Build
                 command: |
-                   DOCKER_TAG=$(docker run singularityhub/sif:${CIRCLE_SHA} --version)
+                   DOCKER_TAG=$(docker run singularityhub/sif:latest --version)
                    echo "Version for Docker tag is ${DOCKER_TAG}"
 
   # This workflow will deploy images on merge to master only
-  build_and_publish_docker_images:
+  docker_with_lifecycle:
     jobs:
       - docker-publish/publish:
-          image: pydicom/dicom-header-cleaner
-          dockerfile: header/Dockerfile
-          path: header
-          filters:
-            branches:
-              only: master
-      - docker-publish/publish:
-          image: pydicom/dicom-header-cleaner
+          image: singularityhub/sif
           tag: latest
-          dockerfile: header/Dockerfile
-          path: header
           filters:
             branches:
-              only: master
+              ignore: master
+          after_build:
+            - run:
+                name: Publish Docker Tag with SIF Python Version
+                command: |
+                   DOCKER_TAG=$(docker run singularityhub/sif:latest --version)
+                   echo "Version for Docker tag is ${DOCKER_TAG}"
+                   docker push singularityhub/sif:${DOCKER_TAG}
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ workflows:
             - run:
                 name: Preview Docker Tag for Build
                 command: |
-                   DOCKER_TAG=$(docker run singularityhub/sif --version)
+                   DOCKER_TAG=$(docker run singularityhub/sif:${CIRCLE_SHA} --version)
                    echo "Version for Docker tag is ${DOCKER_TAG}"
 
   # This workflow will deploy images on merge to master only

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2.1
+
+orbs:
+  # https://circleci.com/orbs/registry/orb/circleci/docker-publish
+  docker-publish: circleci/docker-publish@0.1.3
+workflows:
+
+  # This workflow will be run on all branches but master (to test)
+  build_without_publishing_job:
+    jobs:
+      - docker-publish/publish:
+          image: singularityhub/sif
+          deploy: false
+          filters:
+            branches:
+              ignore: master
+
+  docker_with_lifecycle:
+    jobs:
+      - docker-publish/publish:
+          deploy: false
+          filters:
+            branches:
+              ignore: master
+          after_build:
+            - run:
+                name: Preview Docker Tag for Build
+                command: |
+                   DOCKER_TAG=$(docker run singularityhub/sif --version)
+                   echo "Version for Docker tag is ${DOCKER_TAG}"
+
+  # This workflow will deploy images on merge to master only
+  build_and_publish_docker_images:
+    jobs:
+      - docker-publish/publish:
+          image: pydicom/dicom-header-cleaner
+          dockerfile: header/Dockerfile
+          path: header
+          filters:
+            branches:
+              only: master
+      - docker-publish/publish:
+          image: pydicom/dicom-header-cleaner
+          tag: latest
+          dockerfile: header/Dockerfile
+          path: header
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
   build_without_publishing_job:
     jobs:
       - docker-publish/publish:
-          image: singularityhub/sif
+          image: singularityhub/sif:latest
           deploy: false
           filters:
             branches:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM singularityware/singularity:3.0
+
+#########################################
+# Singularity SIF Python
+# docker build -t singularityhub/sif .
+# docker run singularityhub/sif
+#########################################
+
+LABEL maintainer vsochat@stanford.edu
+
+RUN apk update && \
+    apt add python3 && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py && \
+    pip install ipython && \
+    mkdir -p /code
+
+ADD . /code
+RUN python3 setup.py install
+ENTRYPOINT ["ipython"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ RUN apk update && \
     mkdir -p /code
 
 ADD . /code
+WORKDIR /code
 RUN python3 setup.py install
 ENTRYPOINT ["ipython"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ FROM singularityware/singularity:3.0
 LABEL maintainer vsochat@stanford.edu
 
 RUN apk update && \
-    apt add python3 && \
+    apk add python3 && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python3 get-pip.py && \
     pip install ipython && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN apk update && \
 ADD . /code
 WORKDIR /code
 RUN python3 setup.py install
-ENTRYPOINT ["ipython"]
+ENTRYPOINT ["sif"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SIF (Python)
 
 Sif Python (sif) is the Python API for working with the Singularity SIF image
-format. This library is under development! The basic functionality so far is to 
-parse the header, only using Python:
+format. This library is under development, and contributions are welcome! 
+The basic functionality so far is to parse the header, only using Python:
 
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 '''
 
-Copyright (C) 2018 Vanessa Sochat.
+Copyright (C) 2018-2019 Vanessa Sochat.
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU Affero General Public License as published by
@@ -115,4 +115,4 @@ if __name__ == "__main__":
               'Programming Language :: Python :: 3',
           ],
 
-          entry_points = {'console_scripts': [ 'spython=spython.client:main' ] })
+          entry_points = {'console_scripts': [ 'sif=sif.client:main' ] })

--- a/sif/client/__init__.py
+++ b/sif/client/__init__.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2019 Vanessa Sochat.
+
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sif
+import argparse
+import sys
+import os
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(description="SIF Python")
+
+    # Global Variables
+    parser.add_argument('--debug', dest="debug", 
+                        help="use verbose logging to debug.", 
+                        default=False, action='store_true')
+
+    parser.add_argument('--quiet', dest="quiet", 
+                        help="show SIF Python verison and exit", 
+                        default=False, action='store_true')
+
+    parser.add_argument('--version', dest="version", 
+                        help="suppress additional output.", 
+                        default=False, action='store_true')
+
+    description = 'actions for SIF Python'
+    subparsers = parser.add_subparsers(help='sif python actions',
+                                       title='actions',
+                                       description=description,
+                                       dest="command")
+
+
+    # Local shell with client loaded
+    shell = subparsers.add_parser("shell",
+                                  help="shell into a session a client.")
+
+    shell.add_argument("image", nargs=1,
+                       help="the image to load into the client", 
+                       type=str, default=None)
+
+    return parser
+
+
+def get_subparsers(parser):
+    '''get_subparser will get a dictionary of subparsers, to help with printing help
+    '''
+
+    actions = [action for action in parser._actions 
+               if isinstance(action, argparse._SubParsersAction)]
+
+    subparsers = dict()
+    for action in actions:
+        # get all subparsers and print help
+        for choice, subparser in action.choices.items():
+            subparsers[choice] = subparser
+
+    return subparsers
+
+
+
+def main():
+    '''main is the entrypoint to the sregistry client. The flow works to first
+    to determine the subparser in use based on the command. The command then
+    imports the correct main (files imported in this folder) associated with
+    the action of choice. When the client is imported, it is actually importing
+    a return of the function get_client() under sregistry/main, which plays
+    the job of "sniffing" the environment to determine what flavor of client
+    the user wants to activate. Installed within a singularity image, this
+    start up style maps well to Standard Container Integration Format (SCIF)
+    apps, where each client is a different entrypoint activated based on the
+    environment variables.
+    '''
+
+    parser = get_parser()
+    subparsers = get_subparsers(parser)
+
+    def help(return_code=0):
+        '''print help, including the software version and active client 
+           and exit with return code.
+        '''
+
+        version = sif.__version__
+
+        print("\nSIF Python v%s" % version)
+        parser.print_help()
+        sys.exit(return_code)
+    
+    # If the user didn't provide any arguments, show the full help
+    if len(sys.argv) == 1:
+        help()
+    try:
+        args = parser.parse_args()
+    except:
+        sys.exit(0)
+
+    if args.debug is False:
+        os.environ['MESSAGELEVEL'] = "DEBUG"
+
+    # Show the version and exit
+    if args.version is True:
+        print(sif.__version__)
+        sys.exit(0)
+
+    from sif.logger import bot
+
+    # Does the user want a shell?
+    if args.command == "shell": from .shell import main
+
+    # Pass on to the correct parser
+    return_code = 0
+    try:
+        main(args)
+        sys.exit(return_code)
+    except UnboundLocalError:
+        return_code = 1
+
+    help(return_code)
+
+if __name__ == '__main__':
+    main()

--- a/sif/client/shell.py
+++ b/sif/client/shell.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2019 Vanessa Sochat.
+
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+# License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from sif.logger import bot
+import sys
+import os
+
+def main(args):
+
+    lookup = { 'ipython': ipython,
+               'python': python,
+               'bpython': bpython }
+
+    shells = ['ipython', 'python', 'bpython']
+
+    # The user must supply an image
+    if args.image is None:
+        bot.exit('You must provide an image to load a SIFHeader client.')
+
+    image = args.image[0]
+
+    # The image must exist
+    if not os.path.exists(image):
+        bot.exit('Cannot find %s' % image)
+
+    # Present order of liklihood to have on system
+    for shell in shells:
+        try:
+            return lookup[shell](image)
+        except ImportError:
+            pass
+    
+
+def ipython(image):
+    '''give the user an ipython shell, optionally load image
+    '''
+    from sif.main import SIFHeader  
+    header = SIFHeader(image)  
+    from IPython import embed
+    embed()
+
+
+def bpython(image):
+    import bpython
+    from sif.main import SIFHeader  
+    header = SIFHeader(image)  
+    bpython.embed(locals_={'header': header,
+                           'image': image,
+                           'SIFHeader': SIFHeader})
+
+def python(image):
+    import code
+    from sif.main import SIFHeader  
+    header = SIFHeader(image)  
+    code.interact(local={"header": header,
+                         'image': image,
+                         'SIFHeader': SIFHeader})

--- a/sif/utils/fileio.py
+++ b/sif/utils/fileio.py
@@ -26,7 +26,6 @@ import re
 import shutil
 import tempfile
 import tarfile
-import requests
 
 import json
 from sif.utils import get_installdir


### PR DESCRIPTION
This pull request will add both a Dockerfile and Continuous Integration on CircleCI to build it. We likely will want to add tests for the SIF Python too, and can do this with Travis so the two run at the same time. Right now, I want to figure out how to get a custom tag working with a Circle Orb.